### PR TITLE
Added fix for bullet lists

### DIFF
--- a/src/moore/static/sass/partials/pages/_news.scss
+++ b/src/moore/static/sass/partials/pages/_news.scss
@@ -117,4 +117,13 @@
 
 .post-detail {
   padding: 60px 0;
+  ul {
+    & {
+      padding-left: 40px;
+      list-style-type: initial;
+      & > li {
+        list-style-type: initial;
+      }
+    }
+  }
 }


### PR DESCRIPTION
### Description of the Change

This fixes bullet lists in news items. This does not solve any other styling issues caused by the materialize framework. 
Materialize overrides a lot of default stylings which can be reverted with the CSS class `.browser-default`.

### Applicable Issues

#471

